### PR TITLE
feat: 添加健康检查 API

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from datetime import datetime
+from typing import Dict
 
 app = FastAPI(title="Demo API", version="1.0.0")
 
@@ -8,9 +10,21 @@ class HelloResponse(BaseModel):
     name: str
 
 @app.get("/health")
-async def health():
-    """Health check endpoint"""
-    return {"status": "healthy", "version": "1.0.0"}
+async def health() -> Dict[str, str]:
+    """
+    Health check endpoint.
+    
+    Returns the service status and current timestamp in ISO8601 format.
+    This endpoint can be used by load balancers and monitoring systems
+    to verify that the API is running correctly.
+    
+    Returns:
+        Dict with 'status' (always 'ok') and ISO8601 formatted 'timestamp'
+    """
+    return {
+        "status": "ok",
+        "timestamp": datetime.utcnow().isoformat() + "Z"
+    }
 
 @app.get("/api/hello")
 async def hello(name: str = "World"):


### PR DESCRIPTION
## 📋 概述

本 PR 为 FastAPI 应用添加了标准的健康检查 API 端点，用于监控服务运行状态。

## 🎯 需求实现

根据需求，实现了以下内容：

### 1. 创建新分支
- 分支名称: `feature/health-check`
- 基于分支: `main`

### 2. 修改 main.py
- 添加/更新了 `GET /health` 端点

### 3. 返回格式
```json
{
  "status": "ok",
  "timestamp": "2025-01-09T12:34:56.789Z"
}
```

## 🔧 实现方案

### 技术细节

1. **时间戳生成**
   - 使用 `datetime.utcnow()` 获取 UTC 时间
   - 格式化为 ISO8601 标准格式
   - 添加 "Z" 后缀表示 UTC 时区

2. **类型注解**
   - 使用 `Dict[str, str]` 明确返回类型
   - 符合 FastAPI 最佳实践

3. **文档完善**
   - 添加详细的 docstring 说明端点用途
   - 注明可用于负载均衡器和监控系统
   - 明确返回值结构

## 📝 代码变更

### main.py
```python
from datetime import datetime
from typing import Dict

@app.get("/health")
async def health() -> Dict[str, str]:
    """
    Health check endpoint.
    
    Returns the service status and current timestamp in ISO8601 format.
    This endpoint can be used by load balancers and monitoring systems
    to verify that the API is running correctly.
    
    Returns:
        Dict with 'status' (always 'ok') and ISO8601 formatted 'timestamp'
    """
    return {
        "status": "ok",
        "timestamp": datetime.utcnow().isoformat() + "Z"
    }
```

## ✅ 测试验证

可以通过以下方式测试：

```bash
# 启动服务
python main.py

# 测试健康检查端点
curl http://localhost:8000/health

# 预期返回
# {"status":"ok","timestamp":"2025-01-09T12:34:56.789Z"}
```

## 🚀 部署建议

1. **监控集成**
   - 配置负载均衡器定期调用 `/health` 端点
   - 建议检查间隔: 10-30 秒
   - 超时设置: 5 秒

2. **告警配置**
   - 如果端点无响应，触发服务告警
   - 如果响应非 200 状态码，触发告警

## 📚 相关文档

- [FastAPI 文档](https://fastapi.tiangolo.com/)
- [ISO8601 时间格式](https://en.wikipedia.org/wiki/ISO_8601)

---

## ✨ Checklist

- [x] 创建新分支 `feature/health-check`
- [x] 修改 main.py 添加健康检查端点
- [x] 返回格式符合要求（status + ISO8601 timestamp）
- [x] 添加详细的代码文档
- [x] 使用类型注解